### PR TITLE
Use HTTPS to clone Git repositories

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,11 +18,11 @@ In order to use the Java formatter, you need  Nuthatch, Nuthatch/Stratego, Nutha
 
     cd $MYGITDIR
 
-    git clone git@github.com:nuthatchery/pgf.git
+    git clone https://github.com/nuthatchery/pgf.git
 
-    git clone git@github.com:nuthatchery/nuthatch.git
-    git clone git@github.com:nuthatchery/nuthatch-stratego.git
-    git clone git@github.com:nuthatchery/nuthatch-javafront.git
+    git clone https://github.com/nuthatchery/nuthatch.git
+    git clone https://github.com/nuthatchery/nuthatch-stratego.git
+    git clone https://github.com/nuthatchery/nuthatch-javafront.git
 
     
     # Also get the JAR file of Stratego/XT


### PR DESCRIPTION
Use HTTPS instead of SSH to clone Git repositories, since then you don’t
need to have SSH set up to clone them.